### PR TITLE
Add Docker support for the wiki

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM rockylinux:8
+
+RUN dnf update -y &&\
+    dnf install -y python3 &&\
+    dnf clean all
+
+# bind volume $CWD > /wiki exists in docker-compose.yml
+RUN mkdir /wiki
+COPY requirements.txt /wiki
+WORKDIR /wiki
+RUN pip3 install -r requirements.txt
+
+EXPOSE 8000
+CMD mkdocs serve -a 0.0.0.0:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  wiki:
+    volumes:
+      - type: bind
+        source: .
+        target: /wiki
+    build:
+      context: .
+    ports:
+      - 8000:8000


### PR DESCRIPTION
This PR adds a Dockerfile and docker-compose.yml, so that users can bring up the wiki in a container and view their changes on the fly.

Usage: On a Docker host from this project directory, execute `docker-compose up`
Visit the wiki in your browser at http://localhost:8000