### PR TITLE
Add Security SIG, add HPC SIG wiki link

### DIFF
--- a/docs/special_interest_groups/index.md
+++ b/docs/special_interest_groups/index.md
@@ -29,8 +29,9 @@ This section goes over the current SIGs that may have sponsors and are active or
 | Desktop                                | Supports and maintains the desktop experience for Rocky Linux                                                                                             |
 | Embedded                               | Embedded Systems                                                                                                                                          |
 | Legacy                                 | Supports and maintains legacy hardware support for Rocky Linux                                                                                            |
-| HPC                                    | Maintains High Performance Computing support for Rocky Linux                                                                                              |
+| [HPC](https://sig-hpc.rocky.page/)     | Maintains High Performance Computing support for Rocky Linux                                                                                              |
 | Hyperscale                             | Hyperscale Computing                                                                                                                                      |
+| [Security](https://sig-security.rocky.page/)|Extra security features and security-hardened override packages (replacing those from the main distribution) for Rocky Linux and other EL distros     |
 
 ### Some that have community interest, but no direct sponsors yet
 


### PR DESCRIPTION
Add entry for the Security SIG, including its wiki link.

Add wiki link for the previously listed HPC SIG.