### PR TITLE
create contributor doc for wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+---
+title: Contributing Guide for Wiki
+author: Krista Burdine, Community Lead
+---
+
+# Contributing Guide
+
+Thank you for your interest in contributing to the Rocky Linux wiki! Below is a guide to help you get started with your contributions.
+
+**Prerequisites**
+
+Before contributing, ensure you have a basic understanding of the following:
+
+* **Git:** Knowledge of Git workflows is essential since all our code management is done through Git.
+
+**Development Environment**
+
+1. **Fork and Clone:** Start by forking the repository and then cloning your fork locally.
+2. **Branch:** Always create a new branch from `develop` for your work. The `develop` branch is our main development branch, and all PRs should target this branch.
+
+**Issue-Driven Development**
+
+* **Find or Create an Issue:** Before starting work on a change, please search for an existing issue.  If no issue addresses your proposed changes, create a new issue to document the problem or potential enhancement.
+* **Link Your PR:** When you open your pull request, clearly link it to the associated issue. This helps maintainers understand the context of your changes.
+
+**Coding Guidelines**
+
+This is a low-code repository.
+* **Code Style:** Follow a similar writing style to the rest of the document or to other documents in the repository.
+* **Components:** Utilize existing UI components from shadcn/ui where possible. If you need to create new components, ensure they are reusable and well-documented.
+
+**Adding Images**
+
+* **Location:** All images should be placed in the `docs/assets/images` directory. Please categorize images by their purpose.
+* **Optimization:** Ensure that images are optimized for the web to enhance performance and reduce load times.
+Best practices include the following:
+  * .jpeg for photos, vector .svg for icons and diagrams;
+  * 150kb or smaller for typical hero/blog/social media images that would go in a post.
+  * Suggested image standards for 2024, as found on [tiny-img.com](https://tiny-img.com/blog/best-image-size-for-website/):
+ 
+    | Website Image Type	| Image Dimensions (W x H) | Image Aspect Ratio |
+    | ---| --- | --- |
+    | Background Image	| 1920 x 1080 pixels |	16:9 |
+    | Hero Image	| 1280 x 720 pixels	| 16:9 |
+    | Website Banner	| 250 x 250 pixels	| 1:1 |
+    | Blog Image	| 1200 x 630 pixels	| 3:2 |
+    | Logo (Rectangle)	| 250 x 100 pixels	| 2:3 |
+    | Logo (Square)	| 100 x 100 pixels	| 1:1 |
+    | Favicon	| 16 x 16 pixels	| 1:1 |
+    | Social Media Icons	| 32 x 32 pixels	| 1:1 |
+    | Lightbox Images (Full Screen)	| 1600 x 500 pixels	| 16:9 |
+    | Thumbnail Image	| 150 x 150 pixels	| 1:1 |
+
+**Translation Contributions**
+
+This wiki is not currently set up for translation, but we welcome your energy to create that momentum. If you have interest in translation, please visit our [Documentation Team](https://chat.rockylinux.org/rocky-linux/channels/documentation) on the Mattermost server and ask to join the localization conversation.
+
+**Pull Request Process**
+
+1. **Pull Request:** Once you are ready, open a pull request against the `develop` branch. Ensure that your PR title and description clearly describe the changes, and **reference the associated issue number (e.g., "Fixes #123")**.
+2. **Review:** Your pull request will be reviewed by maintainers. Be responsive to feedback and make necessary adjustments based on the review.
+3. **Merge:** Once your PR is approved and passes all checks, a maintainer will merge it into the `develop` branch.
+
+**Testing**
+
+Before submitting your pull request, ensure that all existing tests pass and add new tests if you are introducing new features or significant changes.
+
+**Getting Help**
+
+For questions or assistance with your contributions, please reach out via our [Mattermost server](https://chat.rockylinux.org/rocky-linux/channels/off-topic). 
+
+We appreciate your contributions and look forward to improving the Rocky Linux wiki together!

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,9 @@ title: Welcome
 
 ## About
 
-Rocky Linux is a community enterprise Operating System designed to be fully compatible with Enterprise Linux.
+Rocky Linux is a community-driven Enterprise Linux distribution—
+stable enough for the largest enterprise to rely on it, and community-driven to ensure it stays accessible to all.
+
 
 ## Quick Links
 
@@ -51,6 +53,6 @@ See our current [Contributing](contributing) section for information on how to c
 
 ## Special Thanks
 
-We would like to thank all of those out there for their support on our project. It is thanks to you, our users, ours mirrors, and our sponsors for your continued support that allows us to continue to grow. 
+We would like to thank all of those out there for their support on our project. It is thanks to you, our users, our mirrors, and our sponsors for your continued support that allows us to continue to grow. 
 
 Our sponsors can be found [here](https://rockylinux.org/sponsors).

--- a/docs/team/community/event-reports/23SELF.md
+++ b/docs/team/community/event-reports/23SELF.md
@@ -1,0 +1,47 @@
+# SouthEast LinuxFest ‘23
+
+## Event Report
+
+SELF is a long-running regional Linux festival for homelab enthusiasts, held annually in Charlotte, North Carolina. 
+
+Rocky Linux made its second annual appearance this year, hosting a table and sponsoring after-hours parties both nights of the festival, including food and a local craft beer share. It was a great chance to network and grow the community.
+
+We gave away Rocky swag including stickers, tees, and koozies throughout the event. We promoed a slide show.
+
+Several key team members attended, including Louis, Ben, Krista, Pablo, Skip, Neil, and Taylor. This allowed us to answer lots of questions about Rocky, the RESF, and the relationship between the two. 
+
+Neil gave a talk about [Peridot Build System](https://youtu.be/JtQX3_ZMwSc?feature=shared), teasing several features of the completely overhauled v2.
+
+Having so many team members in one place for a few days created some great synergy. Louis celebrated that, “The real win of the South East Linux Fest isn't that all of us were here... it's that we A) solved two package build issues and B) solved MTU problems, with Skip, Neil, Pablo, and Taylor all in person at the booth with some folks witnessing it in person.”
+
+Various posts about the event from our socials and individual team members:
+
+[Traveling to the event](https://twitter.com/NeilHanlon/status/1666809047839051776)
+
+[Arrived!](https://www.linkedin.com/posts/krista-burdine_rockylinux-southeastlinuxfest-activity-7072602669365825536-a3BF?utm_source=share&utm_medium=member_desktop)
+
+[Neil and Fred](https://twitter.com/KristaBurdine/status/1667618939344486403?s=20)
+
+[Sunday morning Facebook](https://www.facebook.com/rockylinuxofficial/posts/pfbid035Bik5gAnr6gwsJ1j2rmZUVwzg2ZhDwBu7P3p8XJ3CmKoLFa7NJpkAGMnkXmqwQkol?notif_id=1686495744669948&notif_t=feedback_reaction_generic&ref=notif)
+
+[General post on Mastodon](https://fosstodon.org/@rockylinux/110526313054564187)
+
+One of the questions we heard a lot this weekend was, “What makes Rocky Linux stand out?” As a bug-for-bug compatible RHEL clone, in some ways it’s just a matter of preference. One strength of open source is in its diverse solutions. 
+
+But on the other hand, we think this community is something special. We formed around the shared purpose of providing and maintaining a stable Enterprise Linux solution with a commitment to keeping the promise of a ten-year release cycle, in a way that ensures control of it can never be taken from the community by a single person or corporation. And we’ve kept going through the shared value of collaboration, and staying focused on the goal.
+
+In two and a half years we have encountered tricky problems, and shed a little blood, sweat, and tears together to find solutions. We have weathered setbacks and come back stronger each time. We’ve learned from each other, pushed each other to be better, and developed enduring friendships with people around the globe.
+
+As everyone headed home (or for some of us, onward to another event) at the end, the messages poured into the chat channel. 
+
+From the airport Pablo sent, “Really amazing to have been there, already at the airport waiting to go back. Hopefully we'll see each other gain soon.”
+
+Neil reflected, “so glad to have gotten us all together. I'm excited - our project is feeling so much more "real" now that so many of us have met in person. love y'all :heart: and safe travels.”
+
+Meanwhile when Skip got home he sent this message, “*Skip Grube has marked himself safe from the North Carolina freeway.”*
+
+Louis chimed in, “Landed safely. Till we all meet again…”
+
+The Rocky Linux community intends to be around for the long haul, which means, relatively, we are still just getting started. There’s still lots of room for more people to get involved! Whether you are a developer, a security expert, a graphic designer, or a technical writer; whether you’re a seasoned genius or an enthusiastic baby beginner; whether your interest is in Rocky Linux itself or in how you can use it to pursue your own special interest project: we’d love to meet you.
+
+You can meet Rocky community members in several channels, listed in the “community” tab at RockyLinux.org. And maybe one of these days, we’ll meet up with you at a conference, too!


### PR DESCRIPTION
modeled after the rl.o contributor guide, with fewer technical instructions as the wiki primarily houses low- and no-code documents.