### PR TITLE
docs: clarify GPG-signed commits are required for wiki contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ This is the Rocky Linux wiki, built using mkdocs.
 If you wish to propose changes, please fork this repo and PR against the
 development branch. If you are PR'ing against main, you will be asked to
 switch to the development branch.
+
+All contributors must fill out the "SSH & GPG Keys" tab. GPG signing is required for all commits. This requirement is enforced by the Rocky Linux Git Contributor Agreement.

--- a/docs/contributing/start.md
+++ b/docs/contributing/start.md
@@ -48,6 +48,8 @@ It is highly recommended that you fill out the "SSH & GPG Keys" tab. Your ssh
 keys should sync to both the [Rocky Linux GitLab](https://git.rockylinux.org) and
 [RESF Git Service](https://git.resf.org).
 
+It is **required** that you add your GPG key to your account, as all commits to the wiki repository must be GPG signed. This is enforced for all contributions. If you have not set up GPG signing for your git commits, please follow the [GitHub guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) or refer to your platform's documentation.
+
 It is highly recommended that you add an OTP to your account.
 
 ### Signing Agreements

--- a/docs/contributing/start.md
+++ b/docs/contributing/start.md
@@ -44,11 +44,7 @@ By default, if your email address has an account on [libravatar](https://www.lib
 you will automatically have a profile picture assigned. If you do not, you can create one
 by clicking the "Change Avatar" button in the profile tab.
 
-It is highly recommended that you fill out the "SSH & GPG Keys" tab. Your ssh
-keys should sync to both the [Rocky Linux GitLab](https://git.rockylinux.org) and
-[RESF Git Service](https://git.resf.org).
-
-It is **required** that you add your GPG key to your account, as all commits to the wiki repository must be GPG signed. This is enforced for all contributions. If you have not set up GPG signing for your git commits, please follow the [GitHub guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) or refer to your platform's documentation.
+It is **required** that you fill out the "SSH & GPG Keys" tab, as all commits must be GPG signed to contribute to git.rockylinux.org and git.resf.org.
 
 It is highly recommended that you add an OTP to your account.
 


### PR DESCRIPTION
Update contributing/start.md to explicitly state that GPG-signed commits are a requirement for the wiki repository, not just a recommendation. Added a link to setup instructions for configuring GPG signing in git.